### PR TITLE
feat(Read.vue): 左右方向键切换章节

### DIFF
--- a/src/views/Read.vue
+++ b/src/views/Read.vue
@@ -272,8 +272,25 @@ function globalCancelShowing(event: any) {
     comment.showing = false
   }
 }
-onActivated(() => document.addEventListener('click', globalCancelShowing))
-onDeactivated(() => document.removeEventListener('click', globalCancelShowing))
+
+function manageKeydown(event: KeyboardEvent) {
+  // @ts-ignore
+  if (viewerRef.value.$viewer.isShown) return // 显示图片时不予响应
+  if (event.code === 'ArrowRight') {
+    next()
+  } else if (event.code === 'ArrowLeft') {
+    prev()
+  }
+}
+
+onActivated(() => {
+  document.addEventListener('click', globalCancelShowing)
+  document.addEventListener('keydown', manageKeydown)
+})
+onDeactivated(() => {
+  document.removeEventListener('click', globalCancelShowing)
+  document.removeEventListener('keydown', manageKeydown)
+})
 
 onMounted(getContent.syncCall)
 watch(


### PR DESCRIPTION
close #14 
本想用vue的事件监听，但鼠标点击正文或者图片时会失去焦点导致监听事件失效，只有焦点tooltip上才能使用，搞不明白为啥。
于是用原生方法绑定事件了。