### PR TITLE
feat(): 添加打开封面自定义占位符的设置选项

### DIFF
--- a/src/components/BookCard.vue
+++ b/src/components/BookCard.vue
@@ -11,7 +11,7 @@
                 <div>{{ book.InteriorLevel ? `Level ${book.InteriorLevel}` : '' }}</div>
               </div>
             </div>
-            <template v-if="book.Placeholder" v-slot:loading>
+            <template v-if="book.Placeholder && readSetting.enableBlurHash" v-slot:loading>
               <blur-hash :blurhash="book.Placeholder" />
             </template>
           </q-img>
@@ -45,7 +45,10 @@ import { useToNow } from '@/composition/useToNow'
 import { BookInList } from '@/services/book/types'
 import { useQuasar } from 'quasar'
 import BlurHash from '@/components/BlurHash.vue'
+import { useSettingStore } from '@/store/setting'
 
+const settingStore = useSettingStore()
+const { readSetting } = settingStore // 引入setting用于控制图片自定义占位符
 const $q = useQuasar()
 const props = defineProps<{ book: BookInList }>()
 const cover = computed(() => props.book.Cover)

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -15,7 +15,8 @@ export const useSettingStore = defineStore('app.setting', {
       readPageWidth: 0,
       justify: false,
       showButton: true,
-      tapToScroll: false
+      tapToScroll: false,
+      enableBlurHash: true // 不在阅读选项卡下，但需要保存到服务器
     }
   }),
   actions: {

--- a/src/views/Book/BookInfo.vue
+++ b/src/views/Book/BookInfo.vue
@@ -19,7 +19,7 @@
                     </div>
                   </div>
                 </div>
-                <template v-if="book.Placeholder" v-slot:loading>
+                <template v-if="book.Placeholder && readSetting.enableBlurHash" v-slot:loading>
                   <blur-hash :blurhash="book.Placeholder" />
                 </template>
               </q-img>
@@ -123,9 +123,12 @@ import { DateTime } from 'luxon'
 import { CommentType } from '@/services/comment/types'
 import { userReadPositionDB } from '@/utils/storage/db'
 import BlurHash from '@/components/BlurHash.vue'
+import { useSettingStore } from '@/store/setting'
 
 const props = defineProps<{ bid: string }>()
 
+const settingStore = useSettingStore()
+const { readSetting } = settingStore // 引入setting用于控制图片自定义占位符
 const $q = useQuasar()
 const router = useRouter()
 const appStore = useAppStore()

--- a/src/views/Setting.vue
+++ b/src/views/Setting.vue
@@ -15,6 +15,10 @@
               <q-radio v-model="dark" :val="true" label="夜间" />
               <q-radio v-model="dark" val="auto" label="自动" />
             </div>
+            <div class="q-gutter-sm light-radio">
+              <div>其他选项</div>
+              <q-toggle v-model="readSetting.enableBlurHash" label="打开书籍封面自定义占位符" />
+            </div>
           </div>
         </q-tab-panel>
 


### PR DESCRIPTION
close #75 
现在默认是开启状态。
个人感觉关闭此功能观感比较好，因为彩色占位符加载之前封面还是空白的，而且此功能和网站整体风格不太符合。
（建议改成默认关闭或者直接删了