### PR TITLE
提高关键词搜索体验

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@microsoft/signalr": "^6.0.2",
     "@microsoft/signalr-protocol-msgpack": "^6.0.2",
     "@quasar/extras": "^1.12.5",
+    "@vueuse/core": "^8.2.0",
     "blurhash": "^1.1.4",
     "core-js": "^3.21.0",
     "dompurify": "^2.3.5",

--- a/src/components/SearchInput.vue
+++ b/src/components/SearchInput.vue
@@ -36,10 +36,12 @@
 <script lang="ts" setup>
 import { useMergeState } from '@/composition/useMergeState'
 import { computed, ref, toRefs } from 'vue'
-const props = withDefaults(defineProps<{ modelValue?: string; maxWidth?: string }>(), {
-  modelValue: '',
-  maxWidth: '600px'
-})
+const props = withDefaults(
+  defineProps<{ width?: (visible: boolean) => string; modelValue?: string; maxWidth?: string }>(),
+  {
+    modelValue: ''
+  }
+)
 const emits = defineEmits<{ (e: 'search', val: string): void; (e: 'update:modelValue', val: string): void }>()
 
 const inputEleRef = ref<HTMLInputElement | null>(null)
@@ -57,11 +59,11 @@ const [keyword] = useMergeState(toRefs(props).modelValue)
 const visible = ref(false)
 
 const searchBarWidth = computed(() => {
-  return visible.value ? '40vw' : 'auto'
+  return props.width(visible.value)
 })
 
 function syncHandle(evt: string | number | null) {
-  if (evt && typeof evt === 'string') {
+  if (typeof evt === 'string') {
     emits('update:modelValue', evt)
     keyword.value = evt
   }

--- a/src/components/app/Header.vue
+++ b/src/components/app/Header.vue
@@ -30,6 +30,8 @@
         standout
         class="q-ml-md"
         v-model="searchKey"
+        :width="searchInputWidth"
+        max-width="unset"
         @search="search"
       />
 
@@ -173,6 +175,7 @@
 
 <script lang="tsx" setup>
 import { computed, defineComponent, ref } from 'vue'
+import { useWindowSize } from '@vueuse/core'
 import { icon } from '@/plugins/icon'
 import { useAppStore } from '@/store'
 import { useLayout } from './useLayout'
@@ -201,6 +204,15 @@ const reveal = useMedia(
   window.innerWidth <= siderBreakpoint.value
 )
 const router = useRouter()
+
+const { width } = useWindowSize()
+const isWideScreen = computed(() => width.value > 768)
+const searchInputWidth = computed(() => {
+  if (isWideScreen.value) {
+    return (visible: boolean) => (visible ? '40vw' : 'auto')
+  }
+  return (visible: boolean) => '50vw'
+})
 
 const userInfoMenuOptions: Array<Record<string, any>> = [
   {

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -4,7 +4,7 @@
     <div class="q-gutter-y-md">
       <div class="row flex-center">
         <!-- <q-input rounded outlined dense v-model="searchKey" @keyup.enter="search" /> -->
-        <search-input outlined dense v-model="searchKey" @search="search" />
+        <search-input outlined dense :width="searchInputWidth" max-width="600px" v-model="searchKey" @search="search" />
       </div>
       <div class="q-gutter-y-md">
         <q-tabs dense v-model="tab" class="text-teal">
@@ -38,7 +38,7 @@
 </template>
 
 <script setup lang="ts">
-import { defineComponent, onMounted, ref, reactive, watch } from 'vue'
+import { defineComponent, ref, reactive, watch } from 'vue'
 import { getBookList } from '@/services/book'
 import { icon } from '@/plugins/icon'
 import { QGrid, QGridItem } from '@/plugins/quasar/components'
@@ -52,6 +52,9 @@ const props = defineProps<{ keyWords: string }>()
 const router = useRouter()
 const scroll = ref()
 const searchKey = ref(props.keyWords)
+const searchInputWidth = () => {
+  return '60vw'
+}
 const requestBook = async (index, done) => {
   let res = await getBookList({ Page: index, Size: 24, KeyWords: props.keyWords })
   bookData.push(...res.Data)

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -47,11 +47,17 @@ import { BookInList } from '@/services/book/types'
 import { useRouter } from 'vue-router'
 import SearchInput from '@/components/SearchInput.vue'
 
+/** 移除精确搜索的双引号 */
+function getTrimedKeyword(str: string) {
+  return str.replace(/^"(.+)"$/, '$1')
+}
+
 defineComponent({ QGrid, QGridItem, BookCard })
 const props = defineProps<{ keyWords: string }>()
 const router = useRouter()
 const scroll = ref()
-const searchKey = ref(props.keyWords)
+
+const searchKey = ref(getTrimedKeyword(props.keyWords))
 const searchInputWidth = () => {
   return '60vw'
 }
@@ -67,7 +73,7 @@ function search() {
 watch(
   () => props.keyWords,
   () => {
-    searchKey.value = props.keyWords
+    searchKey.value = getTrimedKeyword(props.keyWords)
     scroll.value.reset()
     scroll.value.resume()
     scroll.value.poll()


### PR DESCRIPTION
1. 针对小屏机器，搜索框采用固定长度
2. 搜索页面的搜索框不再根据focus状态缩放
3. 双引号机制不再露出到用户界面，提高编辑体验

- [ ] 是否要把search页的重复搜索行为从push改为replace？一个页面搜索几次后想返回上一页有点困难